### PR TITLE
fix: highlight boxes left behind forever when a node leaves the DOM

### DIFF
--- a/debuggingApps/demo/index.html
+++ b/debuggingApps/demo/index.html
@@ -99,6 +99,24 @@
     </div>
   </div>
 
+  <hr />
+  <div id="orphan-box-test">
+    <h4>Node removed while highlighted (orphaned highlight boxes):</h4>
+    <p>
+      Hover the line below and keep the mouse still - it removes itself 3
+      seconds later. The highlight box (and its ribbon) must disappear together
+      with the node. They used to stay behind permanently: the store dropped the
+      item without removing its boxes, so nothing referenced them any more and
+      no amount of mouse movement could ever clear them. Frameworks that
+      re-render (React, Angular, Vue) hit this on every re-render that replaces
+      a highlighted element.
+    </p>
+    <p id="removeOnHover" data-i18n="title">Hover me and wait 3 seconds</p>
+    <button id="restoreRemoveOnHover" style="padding: 8px 16px; cursor: pointer;">
+      put the line back
+    </button>
+  </div>
+
   <div id="non-loc-i18next">
     <h4>Some instrumented stuff</h4>
     <p data-i18n="translation:aNonI18nextKey;[title]common:anotherNonI18nextKey" title="some non i18next title">
@@ -176,6 +194,33 @@
       document.getElementById('tc-whitespace-text').firstChild.data = '\n    ' + i18next.t('title') + '\n  '
       console.log('textContent test: updated existing text nodes via .data (characterData mutation, no data-i18n)')
     }, 2000)
+
+    // Orphaned highlight boxes: remove a node WHILE it is highlighted, without
+    // moving the mouse (a mouse move would reset the highlight first and hide
+    // the problem). Mirrors what a framework re-render does to a hovered node.
+    ;(function () {
+      var container = document.getElementById('orphan-box-test')
+      var template = document.getElementById('removeOnHover').cloneNode(true)
+
+      function arm (ele) {
+        ele.addEventListener('mouseenter', function () {
+          setTimeout(function () {
+            if (!ele.parentElement) return
+            ele.remove()
+            console.log('orphan box test: removed the highlighted node - its highlight box must be gone too')
+          }, 3000)
+        }, { once: true })
+      }
+
+      arm(document.getElementById('removeOnHover'))
+
+      document.getElementById('restoreRemoveOnHover').addEventListener('click', function () {
+        if (document.getElementById('removeOnHover')) return
+        var fresh = template.cloneNode(true)
+        container.insertBefore(fresh, document.getElementById('restoreRemoveOnHover'))
+        arm(fresh)
+      })
+    })()
   </script>
 
   <!-- <script

--- a/src/parser.js
+++ b/src/parser.js
@@ -383,6 +383,11 @@ export function parseTree (node) {
   // walk
   walk(node, handleNode)
   store.clean()
+  // `uninstrumentedStore.clean` was exported but never called, so entries whose
+  // node had left the document were never evicted: they piled up in the store,
+  // kept being reported to the editor as uninstrumented text, and held on to
+  // their highlight boxes.
+  uninstrumentedStore.clean()
 
   // cleanup
   ignoreMergedEleUniqueIds = []

--- a/src/store.js
+++ b/src/store.js
@@ -5,7 +5,13 @@ const data = {}
 function clean () {
   Object.values(data).forEach(item => {
     if (!document.body.contains(item.node)) {
-      resetHighlight(item.id, item.node)
+      // `resetHighlight` takes the *item* - it reads the overlay elements off
+      // it (`item.highlightBox` / `item.ribbonBox`). Passing `item.id` left
+      // both of them in the DOM while the item itself was deleted below, so
+      // nothing referenced them any more and they could never be cleared.
+      // `ignoreSelected: false`: the node is gone from the document, so a
+      // selection highlight must not outlive it either.
+      resetHighlight(item, item.node, item.keys, false)
       delete data[item.id]
     }
   })

--- a/src/uninstrumentedStore.js
+++ b/src/uninstrumentedStore.js
@@ -5,7 +5,9 @@ const data = {}
 function clean () {
   Object.values(data).forEach(item => {
     if (!document.body.contains(item.node)) {
-      resetHighlight(item.id, item.node)
+      // see store.js: `resetHighlight` reads the overlay elements off the item,
+      // so passing `item.id` orphaned them in the DOM
+      resetHighlight(item, item.node, item.keys, false)
       delete data[item.id]
     }
   })
@@ -28,7 +30,14 @@ function save (id, type, node, txt) {
 }
 
 function remove (id, node) {
-  resetHighlight(id, node)
+  // same as in `clean`: the highlight is tracked on the item, not reachable
+  // from the id. `id` can also be undefined here (the caller in parser.js
+  // derives it from `node.parentElement`, which is null for a node without an
+  // element parent) - that used to throw while destructuring in resetHighlight
+  // and aborted the whole parse run.
+  const item = get(id)
+  if (item) resetHighlight(item, item.node, item.keys, false)
+
   delete data[id]
 }
 


### PR DESCRIPTION
# fix: highlight boxes left behind forever when a node leaves the DOM

## The problem

`resetHighlight(item, node, keys, ignoreSelected)` reads the overlay elements off
its **first argument** — `item.highlightBox` and `item.ribbonBox`:

```js
export function resetHighlight (item, node, keys, ignoreSelected = true) {
  const { id } = item
  ...
  if (item.highlightBox) document.body.removeChild(item.highlightBox)
  if (item.ribbonBox) document.body.removeChild(item.ribbonBox)
```

Three call sites passed an **id** instead of the item:

| call site | call |
| --- | --- |
| `store.clean()` | `resetHighlight(item.id, item.node)` |
| `uninstrumentedStore.clean()` | `resetHighlight(item.id, item.node)` |
| `uninstrumentedStore.remove(id, node)` | `resetHighlight(id, node)` |

Destructuring `{ id }` from a number silently yields `undefined`, so the
`selected[id]` guard passed, `item.highlightBox` / `item.ribbonBox` were both
`undefined`, and **neither box was removed from the DOM** — while the store entry
itself *was* deleted on the next line.

The result is overlay elements that nothing references any more. They cannot be
reset, repositioned or cleared by any code path, they stay at the coordinates
they had when the node vanished, and they accumulate. Every framework re-render
that replaces a highlighted element leaks one (React, Angular, Vue), which is how
I ran into it: a page with a virtualised table had a dozen stale highlight boxes
and ribbons floating over unrelated content after a few minutes of use.

The same mistake also **threw**. `parser.js` derives the id for
`uninstrumentedStore.remove` from `node.parentElement`, which can be `null`:

```js
const id = node.parentElement?.uniqueID
uninstrumentedStore.remove(id, node.parentElement)
```

With `id === undefined`, `resetHighlight(undefined, …)` raised
`Cannot destructure property 'id' of 'item' as it is undefined`, aborting the
whole parse run.

## The fix

- all three call sites pass the item; `uninstrumentedStore.remove` looks it up
  and skips when there is none, which also removes the crash above
- both `clean()`s pass `ignoreSelected: false` — the node is gone from the
  document, so a selection highlight must not outlive it either
- `uninstrumentedStore.clean()` is now actually called. It was exported but
  **never invoked** — only `store.clean()` ran in `parseTree`, so uninstrumented
  entries whose node had left the document were never evicted: they piled up in
  the store, kept being reported to the editor as uninstrumented text, and held
  on to their boxes. I found this because fixing the argument alone left the
  uninstrumented probe still leaking.

## How I verified it

Reproduced first on unmodified `master`, in `debuggingApps/demo`, with a plain
light-DOM element — no framework involved: inject an element, hover it (box
created at `top: 264px`), remove the node, wait for the parse cycle.

```
{ probeStillInDom: false, boxesAfterNodeRemoved: ["264px"], BUG_REPRODUCED: true }
```

After the fix, the same probe for both stores, with **no mouse movement at all**
following the removal:

| path | box after removal | editor overlays in `<body>` | store entry |
| --- | --- | --- | --- |
| instrumented (`store`) | gone | 0 | evicted (48 → 47) |
| uninstrumented (`uninstrumentedStore`) | gone | 0 | evicted (48 → 47) |

## Demo

`debuggingApps/demo/index.html` gained a **"Node removed while highlighted"**
section: hover the line, keep the mouse still, and it removes itself after 3
seconds — the mouse must not move, because a mousemove would reset the highlight
first and hide the problem. A button puts the line back so the case can be re-run.
That is the same pattern the modal-occlusion and Angular-`textContent` fixes are
exercised with in that page.

Before: the box stays in the DOM indefinitely. After: box, ribbon and store entry
all go.

## Checklist notes

- `npm run test` passes (and `npm run test:typescript`).
- **No unit tests**: the repo has no runtime test harness — `npm run test` is
  lint, and `test/` holds only tsd type assertions, which cannot express this
  behaviour (it has no public type surface). Hence the demo section above,
  following the existing convention for editor fixes. Happy to add a real test
  harness in a separate PR if you would like one.
- **No documentation change**: no API, option or configurable behaviour changed.
  Happy to add a CHANGELOG entry if you would rather have it in the PR than at
  release time.
