### PR TITLE
fix: keys behind the editor popup stayed highlightable

### DIFF
--- a/debuggingApps/demo/index.html
+++ b/debuggingApps/demo/index.html
@@ -117,6 +117,23 @@
     </button>
   </div>
 
+  <hr />
+  <div id="editor-chrome-test">
+    <h4>Hovering behind the editor popup:</h4>
+    <p>
+      Drag the editor popup over the line below, so the popup covers it. Moving
+      the cursor near the covered line must NOT highlight it - the popup is
+      editor chrome and counts as an occluder, exactly like the modal backdrop
+      above. It used to highlight anyway, because the popup carries the same
+      <code>data-i18next-editor-element</code> marker as the editor's own hover
+      overlays. Hovering a highlighted line's ribbon must still keep the
+      highlight, as before.
+    </p>
+    <p data-i18n="title" style="background-color: #6a9ac93b;">
+      Drag the editor popup over me, then hover me
+    </p>
+  </div>
+
   <div id="non-loc-i18next">
     <h4>Some instrumented stuff</h4>
     <p data-i18n="translation:aNonI18nextKey;[title]common:anotherNonI18nextKey" title="some non i18next title">

--- a/src/ui/mouseDistance.js
+++ b/src/ui/mouseDistance.js
@@ -8,6 +8,11 @@ import {
   resetHighlight
 } from './highlightNode.js'
 
+// our own overlays: they sit on top of the very node they belong to, so they
+// must never count as something covering it
+const ownOverlaySelector =
+  '.i18next-editor-highlight, .i18next-editor-button-container, .i18next-editor-button'
+
 // Check if a node is visually covered by another element (e.g. modal backdrop)
 function isOccluded (node) {
   const rect = node.getBoundingClientRect()
@@ -19,8 +24,12 @@ function isOccluded (node) {
   const topEl = document.elementFromPoint(x, y)
   if (!topEl) return true
 
-  // Ignore our own editor overlay elements (highlight boxes, ribbon boxes, etc.)
-  if (topEl.dataset && topEl.dataset.i18nextEditorElement === 'true') return false
+  // `data-i18next-editor-element` marks two very different things: our own
+  // hover overlays (above), and the editor chrome - popup, its iframe, its drag
+  // overlay - which really does cover the page. Treating both as "not
+  // occluding" is why keys behind the editor popup stayed highlightable.
+  if (topEl.closest && topEl.closest(ownOverlaySelector)) return false
+  if (topEl.dataset && topEl.dataset.i18nextEditorElement === 'true') return true
 
   // The element at point should be the node itself or a descendant/ancestor
   return !node.contains(topEl) && !topEl.contains(node)


### PR DESCRIPTION
# fix: keys behind the editor popup stayed highlightable

> **Disclosure:** this PR is AI-assisted (written with Claude Code, reviewed by
> me). The updated version addresses the review feedback: the centre → cursor
> hit-testing change has been dropped entirely, this is now only the marker
> classification fix.

## The real-world symptom

Our app is a React app (react-i18next + locize) with a dev page listing every
translation string as a wide table (~500 rows). With the editor popup open,
keys kept showing **under the popup**: moving the cursor over or near the panel
highlighted the table rows running beneath it, boxes and ribbons included.

Re-tested against the same page with this branch (via a pnpm-patched build of
the package): moving the cursor on the popup highlights nothing beneath it, and
sliding from a highlighted row onto its own ribbon still keeps the highlight.
One consequence of keeping the centre-point test, verified as expected: a row
whose *centre* sits under the popup is not hoverable even on its visible part —
same as an element half-behind the modal backdrop has always behaved.

## The problem

`data-i18next-editor-element` marks two very different kinds of element:

- our own hover overlays — the highlight box and the ribbon, which sit on top of
  the very node they belong to and must **not** count as covering it, and
- the editor chrome — the popup, its iframe, its drag overlay — which really
  **does** cover the page.

`isOccluded` had a single rule returning "not occluded" for both:

```js
if (topEl.dataset && topEl.dataset.i18nextEditorElement === 'true') return false
```

So every key behind the editor popup stayed highlightable: moving the cursor
near the panel highlighted text underneath it, and an existing highlight was not
cleared while the cursor sat on the panel.

## The fix

Our own overlays are matched by class
(`.i18next-editor-highlight`, `.i18next-editor-button-container`,
`.i18next-editor-button`) via `closest()` — which also picks up their unclassed
children (ribbon arrow, icon `<img>`) — and keep the previous "never occluding"
behaviour. Anything else carrying `data-i18next-editor-element` now counts as an
occluder.

The occlusion check still tests the element's **centre point**, exactly as
before. (An earlier version of this PR switched it to cursor-position
hit-testing; that was dropped after review, since `isOccluded` runs for every
stored item on each mousemove and cursor hit-testing would have pre-empted the
5px/10px proximity tolerance for items not directly under the cursor —
including the 35px approach to the ribbon.)

## How I verified it

In `debuggingApps/demo/index.html` (section added in this PR): with the popup
dragged over a line, hovering near that line no longer highlights it; hovering a
highlighted line's own ribbon still keeps the highlight; and text behind the
modal backdrop — the case this check was originally added for — is still not
highlighted.

## Checklist notes

- `npm run test` passes (and `npm run test:typescript`).
- No unit tests: the repo has no runtime test harness (`npm run test` is lint,
  `test/` holds tsd type assertions), hence the demo section.
- No documentation change: no API, option or configurable behaviour changed.
