### PR TITLE
fix: stale hover highlights when the page scrolls under a stationary mouse

### DIFF
--- a/debuggingApps/demo/index.html
+++ b/debuggingApps/demo/index.html
@@ -134,6 +134,20 @@
     </p>
   </div>
 
+  <hr />
+  <div id="scroll-stale-test">
+    <h4>Scroll with the mouse held still (stale hover highlights):</h4>
+    <p>
+      Hover the line below, then scroll the page with the wheel without moving
+      the mouse. The highlight must follow the distance rule as if the mouse had
+      moved: it disappears once the line is no longer under the cursor. It used
+      to stay behind, because highlights were recomputed on mousemove only - the
+      box is positioned in page coordinates, so it scrolled away with the content
+      and nothing ever cleared it.
+    </p>
+    <p data-i18n="title">Hover me, then scroll without moving the mouse</p>
+  </div>
+
   <div id="non-loc-i18next">
     <h4>Some instrumented stuff</h4>
     <p data-i18n="translation:aNonI18nextKey;[title]common:anotherNonI18nextKey" title="some non i18next title">

--- a/src/ui/mouseDistance.js
+++ b/src/ui/mouseDistance.js
@@ -35,10 +35,24 @@ function isOccluded (node) {
   return !node.contains(topEl) && !topEl.contains(node)
 }
 
+// A highlight box is positioned in page coordinates when it is created, so an
+// item that is off-screen with a box still owns a visible overlay somewhere in
+// the document. The viewport check below therefore skips the *highlighting*
+// work for such items, but never the reset. A selected key's box is deliberately
+// left alone (resetHighlight's default ignoreSelected guard): the selection
+// outlives scrolling, only hover highlights are cleared here.
+function hasOverlay (item) {
+  return !!(item.highlightBox || item.ribbonBox)
+}
+
 const debouncedUpdateDistance = debounce(function (e, observer) {
   Object.values(store.data).forEach(item => {
-    // if not visible do not calculate distance of mouse
-    if (!isInViewport(item.node)) return
+    // if not visible do not calculate distance of mouse - but do clear a
+    // highlight it may still be holding, it cannot be under the mouse
+    if (!isInViewport(item.node)) {
+      if (hasOverlay(item)) resetHighlight(item, item.node, item.keys)
+      return
+    }
     // if covered by modal/overlay do not highlight
     if (isOccluded(item.node)) { resetHighlight(item, item.node, item.keys); return }
 
@@ -55,8 +69,12 @@ const debouncedUpdateDistance = debounce(function (e, observer) {
   })
 
   Object.values(uninstrumentedStore.data).forEach(item => {
-    // if not visible do not calculate distance of mouse
-    if (!isInViewport(item.node)) return
+    // if not visible do not calculate distance of mouse - but do clear a
+    // highlight it may still be holding, it cannot be under the mouse
+    if (!isInViewport(item.node)) {
+      if (hasOverlay(item)) resetHighlight(item, item.node, item.keys)
+      return
+    }
     // if covered by modal/overlay do not highlight
     if (isOccluded(item.node)) { resetHighlight(item, item.node, item.keys); return }
 
@@ -70,14 +88,46 @@ const debouncedUpdateDistance = debounce(function (e, observer) {
 }, 50)
 
 let currentFC
+let scrollFC
+// last known mouse position, in viewport coordinates
+let lastClientX = 0
+let lastClientY = 0
+let hasLastMouse = false
 
 export function startMouseTracking (observer) {
   currentFC = function handle (e) {
+    lastClientX = e.clientX
+    lastClientY = e.clientY
+    hasLastMouse = true
+
     debouncedUpdateDistance(e, observer)
   }
   document.addEventListener('mousemove', currentFC)
+
+  // Highlights used to be recomputed on mousemove only, so scrolling with the
+  // mouse held still left them behind: a highlight box is positioned in page
+  // coordinates, it scrolls away together with the content and nothing ever
+  // cleared it. Run the same distance check on scroll, rebuilding the mouse
+  // page position from its last viewport position plus the current scroll
+  // offset - the mouse did not move, the content under it did.
+  scrollFC = function handleScroll () {
+    if (!hasLastMouse) return
+
+    const scrollX = window.scrollX || 0
+    const scrollY = window.scrollY || 0
+
+    // mouseDistanceFromElement reads pageX/pageY only
+    debouncedUpdateDistance({
+      pageX: lastClientX + scrollX,
+      pageY: lastClientY + scrollY
+    }, observer)
+  }
+  // Capture phase: `scroll` does not bubble, and the page may well scroll in a
+  // container instead of the document itself.
+  window.addEventListener('scroll', scrollFC, true)
 }
 
 export function stopMouseTracking () {
   document.removeEventListener('mousemove', currentFC)
+  if (scrollFC) window.removeEventListener('scroll', scrollFC, true)
 }


### PR DESCRIPTION
# fix: stale hover highlights when the page scrolls under a stationary mouse

> **Disclosure:** this PR is AI-assisted (written with Claude Code, reviewed by
> me). The updated version is slimmed down per the review: only the `scroll`
> listener and the off-screen reset remain. The `repositionIfDrifted` part has
> been dropped (repositioning in place, rather than recreating the box, would be
> the right approach — happy to attempt that as a separate PR or leave it), and
> the selected-key claims from the original description were wrong and are
> retracted: the off-screen reset deliberately does **not** touch a selected
> key's box, and `selectedHighlight` has no ribbon.

## The real-world symptom

Our app is a React app (react-i18next + locize) whose UI scrolls inside a
container (a Radix ScrollArea), not the document — `window.scrollY` stays 0.
On a dev page listing every translation string as a table row (~500 rows),
hovering a row and then scrolling the table with the wheel left the highlight
box and ribbon floating over different rows: the mouse never moved, so nothing
ever recomputed. This is also why the `scroll` listener is registered in the
capture phase — a document-level listener never fires for that container.

Re-tested against the same page with this branch (via a pnpm-patched build of
the package): the highlight now clears on scroll. One thing that deliberately
does **not** change: a *selected* key's box still stays where it was created
while its text scrolls away, since the selection must survive scrolling and
nothing repositions existing boxes — that's the in-place repositioning
follow-up discussed in the review.

## The problem

A highlight box is positioned in page coordinates once, when it is created, and
highlights were only ever recomputed on `mousemove`. So scrolling with the mouse
held still left a hover highlight behind: the box scrolled away together with
the content and nothing ever cleared it — it just sat over whatever scrolled
into its place.

## The fix

Two pieces, both in `src/ui/mouseDistance.js`:

- `startMouseTracking` also listens for **`scroll`** and re-runs the same
  distance check, rebuilding the mouse page position from its last viewport
  position plus the current scroll offset (`mouseDistanceFromElement` reads
  `pageX`/`pageY` only). Registered in the **capture phase**, because `scroll`
  does not bubble and the page often scrolls in a container rather than in the
  document itself. `stopMouseTracking` unbinds it, so the navigate/edit toggle
  and the popup minimize/restore paths stay symmetric.
- The `isInViewport` early return no longer skips the reset. It still avoids the
  distance maths for off-screen items, but it also skipped clearing a hover
  highlight those items were still holding — and since the box lives in page
  coordinates, an off-screen item can very much own a visible overlay. Only
  items that actually hold a box pay any extra work. Without this the scroll
  handler cannot help in the common case, where the hovered node is exactly what
  scrolled out of view. A selected key's box is deliberately left alone
  (`resetHighlight`'s default `ignoreSelected` guard): the selection outlives
  scrolling, only hover highlights are cleared here.

## How I verified it

In `debuggingApps/demo/index.html` (section added in this PR): hover a line,
scroll it out from under the stationary cursor with the wheel — the highlight is
cleared on the scroll event instead of staying behind over unrelated content.

## Checklist notes

- `npm run test` passes (and `npm run test:typescript`).
- No unit tests: the repo has no runtime test harness, hence the demo section.
- No documentation change: no API, option or configurable behaviour changed.
