### PR TITLE
feat: opt-in shadow DOM support via the shadowDOM option

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,32 @@ For full control, target the stable CSS class:
 .locize-incontext-ribbon { bottom: 80px; right: 10px; }
 ```
 
+## shadow DOM
+
+If your translated content lives inside an **open shadow root**, the editor does
+not see it by default: a shadow boundary stops DOM traversal *and* mutation
+records, so neither the parser nor the `MutationObserver` on `document.body`
+reaches into it.
+
+Turn it on with the `shadowDOM` option:
+
+```js
+i18next.use(locizeEditorPlugin({ shadowDOM: true }))
+// or startStandalone({ shadowDOM: true })
+// or <script id="locize" shadowdom="true" ...>
+```
+
+With the option on, the editor walks into open shadow roots, observes each of
+them individually (nested ones included), and hooks
+`Element.prototype.attachShadow` so shadow roots created *after* the editor
+started are picked up as well - the usual case, since the editor script usually
+runs before the content is rendered into its shadow root. Closed shadow roots
+(`{ mode: 'closed' }`) are only reachable if they are attached after the editor
+started.
+
+It is off by default because it widens what the editor touches, which is
+unnecessary for pages that do not use shadow DOM.
+
 ## troubleshooting
 
 If the editor popup stays blank or "could not connect" is shown:

--- a/debuggingApps/demo/index.html
+++ b/debuggingApps/demo/index.html
@@ -168,6 +168,24 @@
     </div>
   </div>
 
+  <hr />
+  <div id="shadow-dom-test">
+    <h4>Shadow DOM test:</h4>
+    <p>
+      All the text below lives inside an <em>open</em> shadow root, so neither
+      <code>childNodes</code> traversal from <code>document.body</code> nor the
+      MutationObserver on it reaches the content - each shadow root has to be
+      observed on its own. Needs the opt-in <code>shadowDOM: true</code> option
+      (set below); with the option off, none of it shows up in the editor.
+    </p>
+    <p>1. shadow root attached before locize starts:</p>
+    <shadow-early></shadow-early>
+    <p>2. shadow root attached ~7s after locize started (the common case - the editor script runs before the components mount):</p>
+    <div id="shadow-late-host"></div>
+    <p>3. nested shadow root (a component inside a component):</p>
+    <shadow-nested></shadow-nested>
+  </div>
+
   <div id="non-loc-i18next">
     <h4>Some instrumented stuff</h4>
     <p data-i18n="translation:aNonI18nextKey;[title]common:anotherNonI18nextKey" title="some non i18next title">
@@ -272,6 +290,80 @@
         arm(fresh)
       })
     })()
+
+    // Shadow DOM: content rendered inside an open shadow root. `attachShadow`
+    // happens at three different points in time on purpose - before locize
+    // starts, long after it started, and nested inside another shadow root.
+    function shadowMarkup (label) {
+      return (
+        '<style>p { margin: 4px 0 } .box { padding: 8px; border: 1px dashed #6a9ac9 }</style>' +
+        '<div class="box">' +
+        '<p><em>' + label + '</em></p>' +
+        '<p data-i18n="title">instrumented (data-i18n), loading...</p>' +
+        '<p data-i18n="[title]test.title;common:button.hoverMe" title="Works on title">instrumented with title attribute, loading...</p>' +
+        '<p>Welcome to test the i18next incontext editor</p>' +
+        '</div>'
+      )
+    }
+
+    function localizeShadow (root) {
+      // loc-i18next only walks the light DOM, so translate by hand here
+      root.querySelectorAll('[data-i18n]').forEach(function (ele) {
+        const spec = ele.getAttribute('data-i18n')
+        spec.split(';').forEach(function (part) {
+          if (!part) return
+          const attrMatch = part.match(/^\[(.+)\](.+)$/)
+          if (attrMatch) {
+            ele.setAttribute(attrMatch[1], i18next.t(attrMatch[2]))
+          } else {
+            ele.textContent = i18next.t(part)
+          }
+        })
+      })
+    }
+
+    class ShadowEarly extends HTMLElement {
+      connectedCallback () {
+        if (this.shadowRoot) return
+        this.attachShadow({ mode: 'open' }).innerHTML = shadowMarkup(
+          'inside shadow root, attached before locize started'
+        )
+      }
+    }
+    customElements.define('shadow-early', ShadowEarly)
+
+    class ShadowNested extends HTMLElement {
+      connectedCallback () {
+        if (this.shadowRoot) return
+        const outer = this.attachShadow({ mode: 'open' })
+        outer.innerHTML = '<p>outer shadow root:</p>'
+        const inner = document.createElement('div')
+        outer.appendChild(inner)
+        inner.attachShadow({ mode: 'open' }).innerHTML = shadowMarkup(
+          'inside a shadow root nested in another shadow root'
+        )
+      }
+    }
+    customElements.define('shadow-nested', ShadowNested)
+
+    setTimeout(function () {
+      document.querySelectorAll('shadow-early, shadow-nested').forEach(function (host) {
+        localizeShadow(host.shadowRoot)
+        host.shadowRoot.querySelectorAll('div').forEach(function (ele) {
+          if (ele.shadowRoot) localizeShadow(ele.shadowRoot)
+        })
+      })
+      console.log('shadow DOM test: translated content inside the shadow roots present at startup')
+    }, 2000)
+
+    setTimeout(function () {
+      const host = document.createElement('div')
+      const root = host.attachShadow({ mode: 'open' })
+      root.innerHTML = shadowMarkup('inside shadow root, attached after locize started')
+      document.getElementById('shadow-late-host').appendChild(host)
+      localizeShadow(root)
+      console.log('shadow DOM test: attached a shadow root after locize started')
+    }, 7000)
   </script>
 
   <!-- <script
@@ -286,7 +378,7 @@ type="module"
     // import { locizePlugin } from '/../../src/locizePlugin.js'
 
     i18next
-      .use(locizeEditorPlugin({ show: true }))
+      .use(locizeEditorPlugin({ show: true, shadowDOM: true }))
       // .use(locizePlugin)
       .init(
         {

--- a/index.d.mts
+++ b/index.d.mts
@@ -70,6 +70,14 @@ export function locizeEditorPlugin(opt?: {
    * `.locize-incontext-ribbon` CSS class instead.
    */
   ribbonPosition?: 'bottom-right' | 'bottom-left'
+  /**
+   * Also parse and observe content inside **open shadow roots**. Off by
+   * default: a shadow boundary blocks DOM traversal and mutation records, so
+   * supporting it means walking into every shadow root and hooking
+   * `Element.prototype.attachShadow` to catch the roots attached later -
+   * unnecessary for pages that don't use shadow DOM.
+   */
+  shadowDOM?: boolean
 }): LocizePlugin
 
 /**
@@ -104,6 +112,7 @@ export function startStandalone(opt?: {
   projectId?: string
   version?: string
   ribbonPosition?: 'bottom-right' | 'bottom-left'
+  shadowDOM?: boolean
   implementation?: Implementation
 }): void
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -70,6 +70,14 @@ export function locizeEditorPlugin(opt?: {
    * `.locize-incontext-ribbon` CSS class instead.
    */
   ribbonPosition?: 'bottom-right' | 'bottom-left'
+  /**
+   * Also parse and observe content inside **open shadow roots**. Off by
+   * default: a shadow boundary blocks DOM traversal and mutation records, so
+   * supporting it means walking into every shadow root and hooking
+   * `Element.prototype.attachShadow` to catch the roots attached later -
+   * unnecessary for pages that don't use shadow DOM.
+   */
+  shadowDOM?: boolean
 }): LocizePlugin
 
 /**
@@ -104,6 +112,7 @@ export function startStandalone(opt?: {
   projectId?: string
   version?: string
   ribbonPosition?: 'bottom-right' | 'bottom-left'
+  shadowDOM?: boolean
   implementation?: Implementation
 }): void
 

--- a/src/observer.js
+++ b/src/observer.js
@@ -1,5 +1,12 @@
-import { debounce } from './utils.js'
+import { debounce, debugLog } from './utils.js'
 import { validAttributes } from './vars.js'
+
+const defaultObserverConfig = {
+  attributes: true,
+  childList: true,
+  characterData: true,
+  subtree: true
+}
 
 const mutationTriggeringElements = {}
 
@@ -173,17 +180,30 @@ export function createObserver (ele, handle) {
     if (triggerMutation) debouncedHandler()
   })
 
+  // remember the config `start` was called with, so additional roots
+  // (shadow roots) can be observed with the very same settings
+  let activeConfig = defaultObserverConfig
+
   return {
-    start: (
-      observerConfig = {
-        attributes: true,
-        childList: true,
-        characterData: true,
-        subtree: true
-      }
-    ) => {
+    start: (observerConfig = defaultObserverConfig) => {
+      activeConfig = observerConfig
       handle([ele]) // handle initial content - might be we're not using i18next that triggers mutations on translation (think of static content)
       observer.observe(ele, observerConfig)
+    },
+    // Observe an additional root with the same MutationObserver and parse it
+    // right away. Used for shadow roots: a shadow boundary stops both DOM
+    // traversal and mutation records, so the `document.body` observer never
+    // learns about anything happening inside one.
+    observeRoot (root) {
+      if (!root) return
+
+      try {
+        handle([root])
+      } catch (err) {
+        debugLog('failed to parse additional root', root, err)
+      }
+
+      observer.observe(root, activeConfig)
     },
     skipNext () {
       internalChange = true

--- a/src/parser.js
+++ b/src/parser.js
@@ -6,6 +6,7 @@ import {
 import { store } from './store.js'
 import { uninstrumentedStore } from './uninstrumentedStore.js'
 import { validAttributes, ignoreElements } from './vars.js'
+import { isShadowDOMEnabled } from './shadowRoots.js'
 import { getI18nMetaFromNode } from './utils'
 
 import './shims/uniqueID.js'
@@ -42,6 +43,11 @@ function walk (node, func) {
   ) {
     walk(children[i], func)
   }
+
+  // with the `shadowDOM` option on, descend into an open shadow root as well:
+  // `childNodes` stops at the shadow boundary, so text rendered inside a
+  // shadow root would stay invisible to the editor
+  if (isShadowDOMEnabled() && node.shadowRoot) walk(node.shadowRoot, func)
 }
 
 function extractHiddenMeta (id, type, meta, children) {

--- a/src/process.js
+++ b/src/process.js
@@ -1,5 +1,6 @@
 import { parseTree, setImplementation } from './parser.js'
 import { createObserver } from './observer.js'
+import { observeShadowRoots, setShadowDOMEnabled } from './shadowRoots.js'
 import { startMouseTracking } from './ui/mouseDistance.js'
 import { initDragElement, initResizeElement } from './ui/popup.js'
 import { Popup, popupId, showPopupError } from './ui/elements/popup.js'
@@ -26,7 +27,7 @@ export function start (
   const scriptEle = document.getElementById('locize')
 
   let config = {}
-  ;['projectId', 'version', 'ribbonPosition'].forEach(attr => {
+  ;['projectId', 'version', 'ribbonPosition', 'shadowDOM'].forEach(attr => {
     if (!scriptEle) return
     let value =
       scriptEle.getAttribute(attr.toLowerCase()) ||
@@ -41,6 +42,8 @@ export function start (
   api.config = config
   api.init(implementation)
   setImplementation(implementation)
+  // opt-in: off by default, so nothing about the light-DOM behaviour changes
+  setShadowDOMEnabled(config.shadowDOM)
 
   // start stuff
   implementation?.bindLanguageChange(lng => {
@@ -58,6 +61,11 @@ export function start (
       api.sendCurrentParsedContent()
     })
     observer.start()
+
+    // the observer above only sees the light DOM - with the `shadowDOM` option
+    // on, shadow roots are observed one by one, including those attached after
+    // this point (no-op while the option is off)
+    observeShadowRoots(observer)
 
     startMouseTracking(observer)
 

--- a/src/shadowRoots.js
+++ b/src/shadowRoots.js
@@ -1,0 +1,97 @@
+/* global Element */
+import { debugLog } from './utils.js'
+
+// A shadow root is a boundary for DOM traversal AND for mutation records: the
+// MutationObserver on `document.body` never reports anything that happens
+// inside one, not even with `subtree: true`. To support pages whose content
+// lives in a shadow root, every shadow root has to be observed explicitly -
+// the ones that exist when the editor starts, plus the ones created later,
+// which is the common case: the editor script usually runs before the
+// content is rendered into its shadow root.
+//
+// All of this is opt-in via the `shadowDOM` option: it widens what the editor
+// touches (it walks into shadow roots and hooks `Element.prototype.attachShadow`),
+// which is unnecessary for the vast majority of pages. With the option off,
+// every code path guarded by `isShadowDOMEnabled()` behaves exactly as before.
+const HOOK_FLAG = '__locizeAttachShadowHooked'
+
+// every observer that asked to be notified about new shadow roots - normally
+// exactly one, but `start()` may run more than once on a page
+const observers = []
+
+let enabled = false
+
+export function setShadowDOMEnabled (value) {
+  enabled = !!value
+}
+
+export function isShadowDOMEnabled () {
+  return enabled
+}
+
+// A node inside a shadow root is not reachable via `document.body.contains()`,
+// so with shadow DOM support on, connectivity has to be checked with
+// `isConnected` - which also holds across a shadow boundary. Kept as-is when
+// the option is off, to not change eviction behaviour for existing setups.
+export function isNodeStillInDocument (node) {
+  if (!node) return false
+  return enabled ? !!node.isConnected : document.body.contains(node)
+}
+
+function eachShadowRoot (root, fn) {
+  let elements
+
+  try {
+    elements = root.querySelectorAll('*')
+  } catch (err) {
+    debugLog('could not query for shadow roots in', root, err)
+    return
+  }
+
+  for (let i = 0; i < elements.length; i++) {
+    const shadowRoot = elements[i].shadowRoot
+    if (!shadowRoot) continue
+
+    fn(shadowRoot)
+    eachShadowRoot(shadowRoot, fn) // shadow roots can be nested
+  }
+}
+
+function notify (shadowRoot) {
+  observers.forEach(observer => {
+    try {
+      observer.observeRoot(shadowRoot)
+    } catch (err) {
+      debugLog('failed to observe shadow root', shadowRoot, err)
+    }
+  })
+}
+
+function hookAttachShadow () {
+  if (typeof Element === 'undefined') return
+  if (!Element.prototype || !Element.prototype.attachShadow) return
+  if (Element.prototype[HOOK_FLAG]) return
+
+  const nativeAttachShadow = Element.prototype.attachShadow
+
+  Element.prototype.attachShadow = function attachShadow () {
+    const shadowRoot = nativeAttachShadow.apply(this, arguments)
+    notify(shadowRoot)
+    return shadowRoot
+  }
+
+  Object.defineProperty(Element.prototype, HOOK_FLAG, {
+    value: true,
+    enumerable: false,
+    configurable: true
+  })
+}
+
+export function observeShadowRoots (observer) {
+  if (!enabled) return
+  if (typeof document === 'undefined') return
+  if (observers.indexOf(observer) < 0) observers.push(observer)
+
+  eachShadowRoot(document, notify)
+  hookAttachShadow()
+}

--- a/src/store.js
+++ b/src/store.js
@@ -1,10 +1,11 @@
 import { resetHighlight } from './ui/highlightNode.js'
+import { isNodeStillInDocument } from './shadowRoots.js'
 
 const data = {}
 
 function clean () {
   Object.values(data).forEach(item => {
-    if (!document.body.contains(item.node)) {
+    if (!isNodeStillInDocument(item.node)) {
       // resetHighlight needs the item (it holds the overlay elements), not the id;
       // ignoreSelected false: the node is gone, a selection highlight must not outlive it
       resetHighlight(item, item.node, item.keys, false)

--- a/src/ui/mouseDistance.js
+++ b/src/ui/mouseDistance.js
@@ -2,12 +2,30 @@ import { store } from '../store.js'
 import { uninstrumentedStore } from '../uninstrumentedStore.js'
 import { isInViewport, mouseDistanceFromElement } from './utils.js'
 import { debounce } from '../utils.js'
+import { isShadowDOMEnabled } from '../shadowRoots.js'
 import {
   highlight,
   highlightUninstrumented,
   repositionHighlight,
   resetHighlight
 } from './highlightNode.js'
+
+// `document.elementFromPoint` stops at a shadow host and returns the host
+// itself, so a node inside a shadow root always looked occluded by its own
+// host. With the `shadowDOM` option on, drill through (possibly nested)
+// shadow roots to reach the real element under the point.
+function deepElementFromPoint (x, y) {
+  let el = document.elementFromPoint(x, y)
+  if (!isShadowDOMEnabled()) return el
+
+  while (el && el.shadowRoot) {
+    const inner = el.shadowRoot.elementFromPoint(x, y)
+    if (!inner || inner === el) break
+    el = inner
+  }
+
+  return el
+}
 
 // our own overlays: they sit on top of the very node they belong to, so they
 // must never count as something covering it
@@ -24,7 +42,7 @@ const editorChromeSelector = '#i18next-editor-popup, .locize-incontext-ribbon'
 
 // Is this point covered by something other than the node itself?
 function coveredAt (node, x, y) {
-  const topEl = document.elementFromPoint(x, y)
+  const topEl = deepElementFromPoint(x, y)
   if (!topEl) return true
 
   // `data-i18next-editor-element` marks two very different things: our own
@@ -83,7 +101,7 @@ function hasOverlay (item) {
 function cursorOverEditorChrome (e) {
   if (!e || typeof e.clientX !== 'number') return false
 
-  const topEl = document.elementFromPoint(e.clientX, e.clientY)
+  const topEl = deepElementFromPoint(e.clientX, e.clientY)
   if (!topEl || !topEl.closest) return false
   if (topEl.closest(ownOverlaySelector)) return false
 

--- a/src/uninstrumentedStore.js
+++ b/src/uninstrumentedStore.js
@@ -1,10 +1,11 @@
 import { resetHighlight } from './ui/highlightNode.js'
+import { isNodeStillInDocument } from './shadowRoots.js'
 
 const data = {}
 
 function clean () {
   Object.values(data).forEach(item => {
-    if (!document.body.contains(item.node)) {
+    if (!isNodeStillInDocument(item.node)) {
       // resetHighlight needs the item (it holds the overlay elements), not the id
       resetHighlight(item, item.node, item.keys, false)
       delete data[item.id]


### PR DESCRIPTION
# feat: opt-in shadow DOM support via the `shadowDOM` option

> **Draft on purpose.** Now that #249 and #250 are merged, this branch is
> rebased on top of them — the `isOccluded` change here is just the deep
> `elementFromPoint` lookup layered over #249's marker classification. Keeping
> it in draft a little longer while I finish verifying it end to end; I'll mark
> it ready when it is.
>
> **Disclosure:** this PR is AI-assisted (written with Claude Code, reviewed by
> me). Every runtime claim below was re-verified against this exact branch
> before posting.

## The real-world symptom

Our app is a React app (react-i18next + locize) that is loaded **inside a
shadow root** when embedded in its host platform. With the editor as published,
nothing in the app reaches the editor at all — no keys in the key list, no
hover highlights — because everything the editor does stops at the shadow
boundary. We currently run this branch as a pnpm-patched build in that app,
which is where the fixes in #249/#250 were found too.

## The problem

A shadow root is a boundary for *two* things at once:

1. **DOM traversal** — `parser.js`'s `walk` follows `childNodes`, which stops at the boundary.
2. **Mutation records** — a `MutationObserver` on `document.body` with `subtree: true` is *not* notified about anything happening inside a shadow root. Each root has to be observed on its own.

So it is not enough to descend into shadow roots while parsing: they also have to be registered with the observer, including the ones created *after* the editor started — which is the normal case, since the editor script usually runs before the content is rendered into its shadow root.

Two further places assume light DOM only, and both had to be handled for highlighting to work at all:

- `store.clean()` / `uninstrumentedStore.clean()` evict nodes with `document.body.contains(item.node)`, which is `false` across a shadow boundary — so every shadow node was dropped again on the very next parse.
- `isOccluded()` uses `document.elementFromPoint`, which returns the **shadow host**, not the inner element. `!node.contains(topEl) && !topEl.contains(node)` is then true, so every shadow node looked permanently occluded by its own host and was never highlighted.

## Opt-in, off by default

Everything is behind one `shadowDOM` option, off by default, so existing setups are unaffected:

```js
i18next.use(locizeEditorPlugin({ shadowDOM: true }))
// or startStandalone({ shadowDOM: true })
// or <script id="locize" shadowdom="true" ...>
```

Threaded exactly like the existing `ribbonPosition` option (plugin option / `startStandalone` option / lowercase script attribute), typed in `index.d.ts` + `index.d.mts`, documented in the README.

With the option **off**, every new code path short-circuits on the same flag: `walk` does not descend, `observeShadowRoots` is a no-op — including the `attachShadow` hook, which is only ever installed when the option is on — `deepElementFromPoint` returns plain `document.elementFromPoint`, and both stores keep using `document.body.contains`. I deliberately kept the `document.body.contains` → `isConnected` switch behind the flag too, even though `isConnected` is arguably just more correct, so that the default behaviour is bit-for-bit what it is today.

## Changes

| file | what |
| --- | --- |
| `src/shadowRoots.js` (new) | owns the flag; observes every shadow root present at startup (nested included) and hooks `Element.prototype.attachShadow` for roots attached later |
| `src/observer.js` | `observeRoot(root)` — observes an additional root with the same `MutationObserver` and the config `start()` was called with |
| `src/parser.js` | `walk` descends into `node.shadowRoot` |
| `src/store.js`, `src/uninstrumentedStore.js` | connectivity via `isConnected` when enabled |
| `src/ui/mouseDistance.js` | occlusion check drills through (nested) shadow roots |
| `src/process.js` | reads `config.shadowDOM`, accepts a `shadowdom` script attribute |
| `index.d.ts`, `index.d.mts`, `README.md` | option typed + documented |
| `debuggingApps/demo/index.html` | shadow DOM test section |

## Demo / how I verified it

`debuggingApps/demo/index.html` gained a shadow DOM section with three cases, since the timing is what makes this tricky:

1. a shadow root attached **before** locize starts,
2. a shadow root attached **~7s after** it started (the `attachShadow` hook path),
3. a **nested** shadow root (a root inside another root).

Each contains instrumented text (`data-i18n`), an instrumented `title` attribute and one uninstrumented paragraph. The demo enables `shadowDOM: true`.

Re-verified on this exact branch (`npm start`, inspecting the live stores in the browser):

- **With the option on:** all **6** instrumented nodes inside shadow roots are parsed (2 from each of the three cases, the late-attached one included — that's the hook path), with the correct keys (`translation:title`, `common:button.hoverMe|translation:test.title`), out of 28 store entries total; 10 uninstrumented shadow entries are tracked as well. Hovering a shadow node creates a real highlight box **and** ribbon in the light DOM — while plain `document.elementFromPoint` at that same point returns `SHADOW-EARLY` (the host), which is exactly the occlusion bug described above. `Element.prototype.attachShadow` is hooked (idempotent, delegates to the native implementation).
- **With the option off** (toggled at runtime, then re-parsed): connectivity falls back to `document.body.contains`, and all 6 shadow entries are evicted on the very next parse — the pre-existing behaviour, preserved bit-for-bit; `elementFromPoint` stays flat. Turning the option back on re-parses all 6.

`npm run lint` and `npm run test:typescript` both pass.

## Notes / open questions

- **The `attachShadow` hook** is the one invasive part: it is the only way to learn about a shadow root created after startup (there is no event for it). It is installed only when the option is on, is idempotent (non-enumerable flag on the prototype), delegates to the native implementation and returns its result unchanged. Happy to change the approach if you would rather not patch the prototype — e.g. discover new roots lazily during `walk` instead, at the cost of missing roots whose content is rendered without any light-DOM mutation.
- **Closed shadow roots** are reachable only via the hook (i.e. only if attached after startup); `element.shadowRoot` is `null` for them, so the startup scan cannot see them. Documented as such.
- Happy to add a CHANGELOG entry if you want it in the PR rather than at release time.
