### PR TITLE
fix: reposition existing overlays in place when their node moves

### DIFF
--- a/debuggingApps/demo/index.html
+++ b/debuggingApps/demo/index.html
@@ -186,6 +186,33 @@
     <shadow-nested></shadow-nested>
   </div>
 
+  </div>
+
+  <hr />
+  <div id="reposition-test">
+    <h4>Selected key in a scrolling container (overlay follows the text):</h4>
+    <p>
+      The line below sits in a scrollable container, so the document never
+      scrolls and <code>window.scrollY</code> stays 0. Click the button to
+      select it (simulated - selection normally comes from the editor iframe),
+      then scroll the <em>container</em>: the selection box must follow the
+      text, moved in place rather than torn down and re-created. It used to
+      stay fixed on screen while the text moved away underneath it, and the
+      selection guard meant nothing could ever correct it. Scroll the whole
+      page until the line leaves the viewport: the ribbon must hide (floating-ui
+      would otherwise clamp it to the screen edge, pointing at nothing) and come
+      back when the line scrolls back into view.
+    </p>
+    <button id="simulateSelect" style="padding: 8px 16px; cursor: pointer;">
+      select the line below
+    </button>
+    <div id="repositionContainer" style="height: 140px; overflow-y: auto; border: 1px solid #6a9ac9; padding: 8px; margin-top: 8px;">
+      <div style="height: 60px;">(scroll inside this box)</div>
+      <p id="repositionLine" data-i18n="title">Select me, then scroll the container</p>
+      <div style="height: 300px;"></div>
+    </div>
+  </div>
+
   <div id="non-loc-i18next">
     <h4>Some instrumented stuff</h4>
     <p data-i18n="translation:aNonI18nextKey;[title]common:anotherNonI18nextKey" title="some non i18next title">
@@ -364,6 +391,25 @@
       localizeShadow(root)
       console.log('shadow DOM test: attached a shadow root after locize started')
     }, 7000)
+    // Reposition test: mark the line as selected the way the editor would.
+    // Selection is normally driven by a message from the editor iframe, which
+    // needs a locize login - simulate just the selection so the container
+    // scroll case is testable without one.
+    document.getElementById('simulateSelect').addEventListener('click', async function () {
+      const { store } = await import('/../../src/store.js')
+      const { highlight, selectedHighlight } = await import('/../../src/ui/highlightNode.js')
+      const line = document.getElementById('repositionLine')
+      const item = Object.values(store.data).find(function (it) { return it.node === line })
+      if (!item) {
+        console.warn('reposition test: line not parsed yet, try again in a second')
+        return
+      }
+      // hover first, like a real click-to-select: the item keeps its ribbon
+      // through the selection, so the ribbon behaviour is covered too
+      highlight(item, item.node, item.keys)
+      selectedHighlight(item, item.node, item.keys)
+      console.log('reposition test: selection box + ribbon created - now scroll the container')
+    })
   </script>
 
   <!-- <script

--- a/src/ui/elements/highlightBox.js
+++ b/src/ui/elements/highlightBox.js
@@ -1,13 +1,22 @@
-export function HighlightBox (ele, borderColor, shadowColor) {
+// (Re)aligns a box to its reference element. Split out from HighlightBox so an
+// existing box can be moved in place when its node moves (container scroll,
+// reflow) - tearing the box down and re-creating it would flicker.
+export function positionHighlightBox (box, ele) {
   const rect = ele.getBoundingClientRect()
 
+  box.style.top = `${rect.top - 2 + window.scrollY}px`
+  box.style.left = `${rect.left - 2 + window.scrollX}px`
+  box.style.height = `${rect.height + 4}px`
+  box.style.width = `${rect.width + 4}px`
+}
+
+export function HighlightBox (ele, borderColor, shadowColor) {
   const box = document.createElement('div')
   box.classList.add('i18next-editor-highlight')
-  box.style = `position: absolute; z-index: 99999; pointer-events: none; top: ${rect.top - 2 + window.scrollY
-    }px; left: ${rect.left - 2 + window.scrollX}px; height: ${rect.height + 4
-    }px; width: ${rect.width + 4
-    }px; border: ${borderColor === 'none' ? 'none' : `1px solid ${borderColor}`}; border-radius: 15px; ${shadowColor ? `box-shadow: inset 1px 1px 5px rgba(255, 255, 255, 0.1), inset -1px -1px 5px rgba(61, 67, 69, 0.3), 0 0 20px 0 ${shadowColor};` : ''
+  box.style = `position: absolute; z-index: 99999; pointer-events: none; border: ${borderColor === 'none' ? 'none' : `1px solid ${borderColor}`
+    }; border-radius: 15px; ${shadowColor ? `box-shadow: inset 1px 1px 5px rgba(255, 255, 255, 0.1), inset -1px -1px 5px rgba(61, 67, 69, 0.3), 0 0 20px 0 ${shadowColor};` : ''
     }`
+  positionHighlightBox(box, ele)
   box.setAttribute('data-i18next-editor-element', 'true')
 
   return box

--- a/src/ui/highlightNode.js
+++ b/src/ui/highlightNode.js
@@ -1,8 +1,8 @@
 import { colors } from '../vars.js'
 import { RibbonBox } from './elements/ribbonBox.js'
-import { HighlightBox } from './elements/highlightBox.js'
+import { HighlightBox, positionHighlightBox } from './elements/highlightBox.js'
 import { computePosition, flip, shift, offset, arrow } from '@floating-ui/dom'
-import { getOptimizedBoundingRectEle } from './utils.js'
+import { getOptimizedBoundingRectEle, isInViewport } from './utils.js'
 
 // const eleToOutline = [
 //   'DIV',
@@ -29,10 +29,10 @@ import { getOptimizedBoundingRectEle } from './utils.js'
 // const originalStyles = {}
 const selected = {}
 
-// Place the ribbon next to its element. Shared by the initial highlight and by
-// repositionHighlight, so a ribbon that follows drifting content lands exactly
-// where it would have on creation.
-function positionRibbon (rectEle, actions, arrowEle) {
+// Positions (or re-positions) a ribbon box next to its reference element.
+// Split out of highlight() so an existing ribbon can be moved in place when
+// its node moves, instead of being torn down and re-created.
+function positionRibbonBox (rectEle, actions, arrowEle) {
   return computePosition(rectEle, actions, {
     placement: 'right',
     middleware: [
@@ -83,6 +83,43 @@ function positionRibbon (rectEle, actions, arrowEle) {
   })
 }
 
+// Re-aligns an item's existing overlays with its node, in place. A box is
+// positioned in page coordinates once, when it is created - when the node
+// moves without the page scrolling (a scrolling container, a reflow above
+// it), the box stays behind. Moving the existing elements avoids the
+// flicker that destroy-and-recreate would cause on every recompute tick.
+export function repositionOverlays (item, node) {
+  if (!item.highlightBox || !node) return
+
+  const rectEle = getOptimizedBoundingRectEle(node)
+  const rect = rectEle.getBoundingClientRect()
+  const style = item.highlightBox.style
+  const drifted =
+    Math.abs(parseFloat(style.top) - (rect.top - 2 + window.scrollY)) > 1 ||
+    Math.abs(parseFloat(style.left) - (rect.left - 2 + window.scrollX)) > 1 ||
+    Math.abs(parseFloat(style.height) - (rect.height + 4)) > 1 ||
+    Math.abs(parseFloat(style.width) - (rect.width + 4)) > 1
+
+  // The ribbon is placed with floating-ui's shift(), which clamps it into the
+  // viewport - re-placing it for an off-screen node would pin it to the screen
+  // edge, pointing at nothing. Hide it while the node is off-screen; re-placing
+  // it below turns it back on (positionRibbonBox sets display).
+  const ribbonHidden =
+    item.ribbonBox && item.ribbonBox.style.display === 'none'
+  if (item.ribbonBox && !isInViewport(node)) {
+    item.ribbonBox.style.display = 'none'
+    if (drifted) positionHighlightBox(item.highlightBox, rectEle)
+    return
+  }
+
+  if (!drifted && !ribbonHidden) return
+
+  positionHighlightBox(item.highlightBox, rectEle)
+  if (item.ribbonBox && item.ribbonArrow) {
+    positionRibbonBox(rectEle, item.ribbonBox, item.ribbonArrow)
+  }
+}
+
 export function highlight (item, node, keys) {
   // const { id } = item
 
@@ -124,9 +161,9 @@ export function highlight (item, node, keys) {
     const { box: actions, arrow: arrowEle } = RibbonBox(keys)
     document.body.appendChild(actions)
 
-    positionRibbon(rectEle, actions, arrowEle)
+    positionRibbonBox(rectEle, actions, arrowEle)
 
-    // store them for remove
+    // store them for remove and for repositioning in place
     item.ribbonBox = actions
     item.ribbonArrow = arrowEle
   }
@@ -206,34 +243,6 @@ export function selectedHighlight (item, node, keys) {
   // }
 
   selected[id] = true
-}
-
-// A highlight box is positioned in page coordinates once, when it is created,
-// and nothing moved it afterwards - so content that shifts under a still mouse
-// (a container scrolling, a layout change) left the overlay behind on its old
-// spot. Update the existing elements in place instead of removing and
-// rebuilding them: no flicker, no ribbon rebuild, and a selected key's box -
-// which no distance rule is allowed to clear - keeps following its text.
-export function repositionHighlight (item, node) {
-  if (!item.highlightBox) return
-
-  const rectEle = getOptimizedBoundingRectEle(node)
-  const rect = rectEle.getBoundingClientRect()
-  const top = `${rect.top - 2 + window.scrollY}px`
-  const left = `${rect.left - 2 + window.scrollX}px`
-
-  // page scrolling moves rect and scrollY by the same amount, so the page
-  // coordinates stay put and this is a no-op - only real drift gets through
-  if (item.highlightBox.style.top === top && item.highlightBox.style.left === left) return
-
-  Object.assign(item.highlightBox.style, {
-    top,
-    left,
-    height: `${rect.height + 4}px`,
-    width: `${rect.width + 4}px`
-  })
-
-  if (item.ribbonBox && item.ribbonArrow) positionRibbon(rectEle, item.ribbonBox, item.ribbonArrow)
 }
 
 export function recalcSelectedHighlight (item, node, keys) {

--- a/src/ui/mouseDistance.js
+++ b/src/ui/mouseDistance.js
@@ -6,7 +6,7 @@ import { isShadowDOMEnabled } from '../shadowRoots.js'
 import {
   highlight,
   highlightUninstrumented,
-  repositionHighlight,
+  repositionOverlays,
   resetHighlight
 } from './highlightNode.js'
 
@@ -115,14 +115,16 @@ const debouncedUpdateDistance = debounce(function (e, observer) {
   }
 
   Object.values(store.data).forEach(item => {
+    // an existing overlay may belong to content that has moved (container
+    // scroll, reflow above it) - realign it in place first. Matters most for
+    // a selected key's box, which the resets below deliberately leave alone.
+    if (item.highlightBox) repositionOverlays(item, item.node)
     // if not visible do not calculate distance of mouse - but do clear a
     // highlight it may still be holding, it cannot be under the mouse
     if (!isInViewport(item.node)) {
       if (hasOverlay(item)) resetHighlight(item, item.node, item.keys)
       return
     }
-    // content may have moved under a still mouse - keep the overlay on its node
-    repositionHighlight(item, item.node)
     // if covered by modal/overlay do not highlight
     if (isOccluded(item.node, e)) { resetHighlight(item, item.node, item.keys); return }
 
@@ -139,14 +141,16 @@ const debouncedUpdateDistance = debounce(function (e, observer) {
   })
 
   Object.values(uninstrumentedStore.data).forEach(item => {
+    // an existing overlay may belong to content that has moved (container
+    // scroll, reflow above it) - realign it in place first. Matters most for
+    // a selected key's box, which the resets below deliberately leave alone.
+    if (item.highlightBox) repositionOverlays(item, item.node)
     // if not visible do not calculate distance of mouse - but do clear a
     // highlight it may still be holding, it cannot be under the mouse
     if (!isInViewport(item.node)) {
       if (hasOverlay(item)) resetHighlight(item, item.node, item.keys)
       return
     }
-    // content may have moved under a still mouse - keep the overlay on its node
-    repositionHighlight(item, item.node)
     // if covered by modal/overlay do not highlight
     if (isOccluded(item.node, e)) { resetHighlight(item, item.node, item.keys); return }
 


### PR DESCRIPTION
# fix: reposition existing overlays in place when their node moves

> This is the in-place repositioning follow-up sketched in the #250 review.
> The branch was rebased onto current master by @adrai (thanks!) after our
> implementations crossed — their `repositionHighlight` was removed in favour
> of this version; see the comment thread for the resolution and my
> verification of it.
>
> **Disclosure:** this PR is AI-assisted (written with Claude Code, reviewed by
> me). All runtime claims below were re-verified against the rebased branch.

## The real-world symptom

Same app as #250 (React, UI scrolling inside a container — `window.scrollY`
stays 0): selecting a key and then scrolling the container leaves the selection
box fixed on screen while its text moves away underneath it. #250 deliberately
does not touch a selected key's box (the selection must survive scrolling), and
nothing else ever repositions an existing overlay — so the drift is permanent
until the selection changes.

## The fix

Reposition the **existing** overlay elements instead of tearing them down —
destroy-and-recreate on every recompute tick would flicker during a continuous
scroll (the concern raised in the #250 review):

- `highlightBox.js`: the geometry is split out of `HighlightBox` into
  `positionHighlightBox(box, ele)`, used at creation and for realigning.
- `highlightNode.js`: the floating-ui placement is split out of `highlight()`
  into `positionRibbonBox(rectEle, actions, arrowEle)`; the arrow element is
  kept on the item (`item.ribbonArrow`) so an existing ribbon can be
  repositioned; new `repositionOverlays(item, node)` realigns box + ribbon when
  the box's stored position or size drifted more than 1px from the node's
  current rect — top, left, width and height are all compared.
- `mouseDistance.js`: the recompute loop realigns any item holding a box,
  before the viewport/occlusion checks — so it also covers a selected box
  whose node is currently off-screen.
- One consequence handled explicitly: the ribbon is placed with floating-ui's
  `shift()`, which clamps it into the viewport — re-placing it for an
  **off-screen** node would pin it to the screen edge, pointing at nothing
  (found while testing this in our app). So the ribbon is hidden while its
  node is outside the viewport and re-placed (which also re-shows it) when the
  node comes back. The box itself keeps realigning in page coordinates
  regardless. Note this keys off the *window* viewport, like every other
  `isInViewport` check in the editor — a node merely clipped by a scrolling
  container keeps its overlays, which is the pre-existing behaviour for
  highlight boxes too.

Steady-state cost: items without a box pay nothing; items with an aligned box
pay one `getBoundingClientRect` per recompute tick.

## How I verified it

`debuggingApps/demo/index.html` gained a **"Selected key in a scrolling
container"** section — selection is simulated by calling `selectedHighlight`
directly, since real selection needs the editor iframe (noted in the demo).
Measured on this branch:

- container scrolled 60px, `window.scrollY` stayed 0, the line moved up 60px —
  and the selection box followed to the pixel (`style.top` matches the node's
  rect exactly);
- the box after the scroll is the **same DOM element** as before (verified via
  a marker attribute), i.e. moved in place, not recreated;
- scrolling the selected line out of the window viewport hides its ribbon
  (`display: none`) and keeps the box; scrolling it back re-shows the ribbon,
  re-placed exactly 35px right of the text (the configured offset), vertically
  centred;
- hover highlights keep being cleared by #250's scroll logic as before, and a
  fresh highlight appears on content that moved under the stationary cursor.

Also verified against the React app from #250 (container-scrolled table,
pnpm-patched build): the selection box tracks its row during container scroll,
and the ribbon hides when the row scrolls out of the viewport instead of
pinning to the screen edge — that edge-pinning was found by testing an earlier
version of this branch in that app.

`npm run lint` and `npm run test:typescript` pass.

## Notes

- The ribbon reposition reuses the exact placement config `highlight()` uses
  (flip/shift/offset/arrow), so a repositioned ribbon lands where a freshly
  created one would.
- No API, option or configurable behaviour changed.
